### PR TITLE
Improves api response structure

### DIFF
--- a/http/response.go
+++ b/http/response.go
@@ -3,11 +3,8 @@ package http
 import "github.com/emanuelquerty/gymulty/domain"
 
 type Response[T any] struct {
-	Success bool    `json:"success,omitempty"  bson:"success"`
-	Message *string `json:"message,omitempty"  bson:"message"`
-	Count   int     `json:"count,omitempty"  bson:"count"`
-	Type    string  `json:"type,omitempty"  bson:"type"`
-	Data    T       `json:"data,omitempty"  bson:"data"`
+	Count int `json:"count,omitempty"  bson:"count"`
+	Data  T   `json:"data,omitempty"  bson:"data"`
 }
 
 type TenantSignupResponse struct {

--- a/http/tenants.go
+++ b/http/tenants.go
@@ -73,9 +73,7 @@ func (t *TenantHandler) createTenant(w http.ResponseWriter, r *http.Request) *ap
 	}
 
 	res := Response[TenantSignupResponse]{
-		Success: true,
-		Count:   1,
-		Type:    "tenants",
+		Count: 1,
 		Data: TenantSignupResponse{
 			Message: "tenant registered successfully",
 			Tenant:  newTenant,

--- a/http/tenants_test.go
+++ b/http/tenants_test.go
@@ -44,9 +44,7 @@ func TestCreateTenant(t *testing.T) {
 		res := newTenantRequest(tenantStore, userStore, req)
 
 		want := Response[TenantSignupResponse]{
-			Success: true,
-			Count:   1,
-			Type:    "tenants",
+			Count: 1,
 			Data: TenantSignupResponse{
 				Message: "tenant registered successfully",
 				Tenant: domain.Tenant{

--- a/http/users.go
+++ b/http/users.go
@@ -58,11 +58,11 @@ func (u *UserHandler) getUserByID(w http.ResponseWriter, r *http.Request) *appEr
 		return e.withContext(err, "An internal server error ocurred. Please try again later", ErrInternal)
 	}
 
-	res := Response[domain.PublicUser]{
-		Success: true,
-		Count:   1,
-		Type:    "users",
-		Data:    MapToPublicUser(user),
+	res := Response[[]domain.PublicUser]{
+		Count: 1,
+		Data: []domain.PublicUser{
+			MapToPublicUser(user),
+		},
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -94,13 +94,11 @@ func (u *UserHandler) createUser(w http.ResponseWriter, r *http.Request) *appErr
 		return e.withContext(err, "An internal server error ocurred. Please try again later", ErrInternal)
 	}
 
-	message := "user was created successfully"
-	res := Response[domain.PublicUser]{
-		Message: &message,
-		Success: true,
-		Count:   1,
-		Type:    "users",
-		Data:    MapToPublicUser(newUser),
+	res := Response[[]domain.PublicUser]{
+		Count: 1,
+		Data: []domain.PublicUser{
+			MapToPublicUser(newUser),
+		},
 	}
 	resourceURI := fmt.Sprintf("%s://%s%s/%d", r.URL.Scheme, r.Host, r.URL.String(), newUser.ID)
 
@@ -141,13 +139,11 @@ func (u *UserHandler) updateUser(w http.ResponseWriter, r *http.Request) *appErr
 		return e.withContext(err, "An internal server error ocurred. Please try again later", ErrInternal)
 	}
 
-	message := "user was updated successfully"
-	res := Response[domain.PublicUser]{
-		Success: true,
-		Message: &message,
-		Count:   1,
-		Type:    "users",
-		Data:    MapToPublicUser(user),
+	res := Response[[]domain.PublicUser]{
+		Count: 1,
+		Data: []domain.PublicUser{
+			MapToPublicUser(user),
+		},
 	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(res)
@@ -173,15 +169,12 @@ func (u *UserHandler) deleteUserByID(w http.ResponseWriter, r *http.Request) *ap
 		}
 		return e.withContext(err, "An internal server error ocurred. Please try again later", ErrInternal)
 	}
-	message := "user was deleted successfully"
+
 	res := Response[any]{
-		Success: true,
-		Count:   1,
-		Type:    "users",
-		Data:    nil,
-		Message: &message,
+		Count: 1,
+		Data:  nil,
 	}
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 	json.NewEncoder(w).Encode(res)
 	return nil
 }
@@ -203,10 +196,8 @@ func (u *UserHandler) getAllUsers(w http.ResponseWriter, r *http.Request) *appEr
 
 	userCount := len(users)
 	res := Response[[]domain.PublicUser]{
-		Success: true,
-		Count:   userCount,
-		Type:    "users",
-		Data:    MapToPublicUsers(users),
+		Count: userCount,
+		Data:  MapToPublicUsers(users),
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/http/users_test.go
+++ b/http/users_test.go
@@ -46,19 +46,19 @@ func TestGetUser(t *testing.T) {
 		req := httptest.NewRequest("GET", "/api/tenants/1/users/7", nil)
 		res := newUserRequest(userStore, req)
 
-		var got Response[domain.PublicUser]
+		var got Response[[]domain.PublicUser]
 		json.NewDecoder(res.Body).Decode(&got)
 
-		want := Response[domain.PublicUser]{
-			Success: true,
-			Count:   1,
-			Type:    "users",
-			Data: domain.PublicUser{
-				ID:        7,
-				TenantID:  1,
-				FirstName: "Peter",
-				LastName:  "Petrelli",
-				Role:      "admin",
+		want := Response[[]domain.PublicUser]{
+			Count: 1,
+			Data: []domain.PublicUser{
+				{
+					ID:        7,
+					TenantID:  1,
+					FirstName: "Peter",
+					LastName:  "Petrelli",
+					Role:      "admin",
+				},
 			},
 		}
 		assert.Equal(t, want, got, "users should be equal")
@@ -78,19 +78,19 @@ func TestGetUser(t *testing.T) {
 		req := httptest.NewRequest("GET", "/api/tenants/1/users/2", nil)
 		res := newUserRequest(userStore, req)
 
-		var got Response[domain.PublicUser]
+		var got Response[[]domain.PublicUser]
 		json.NewDecoder(res.Body).Decode(&got)
 
-		want := Response[domain.PublicUser]{
-			Success: true,
-			Count:   1,
-			Type:    "users",
-			Data: domain.PublicUser{
-				ID:        2,
-				TenantID:  1,
-				FirstName: "Bruce",
-				LastName:  "Banner",
-				Role:      "trainer",
+		want := Response[[]domain.PublicUser]{
+			Count: 1,
+			Data: []domain.PublicUser{
+				{
+					ID:        2,
+					TenantID:  1,
+					FirstName: "Bruce",
+					LastName:  "Banner",
+					Role:      "trainer",
+				},
 			},
 		}
 		assert.Equal(t, want, got, "users should be equal")
@@ -161,23 +161,21 @@ func TestCreateUser(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/api/tenants/1/users", bodyBuff)
 		res := newUserRequest(userStore, req)
 
-		var got Response[domain.PublicUser]
+		var got Response[[]domain.PublicUser]
 		json.NewDecoder(res.Body).Decode(&got)
 
-		message := "user was created successfully"
-		want := Response[domain.PublicUser]{
-			Success: true,
-			Message: &message,
-			Count:   1,
-			Type:    "users",
-			Data: domain.PublicUser{
-				ID:        user.ID,
-				TenantID:  user.TenantID,
-				FirstName: user.FirstName,
-				LastName:  user.LastName,
-				Role:      user.Role,
-				CreatedAt: user.CreatedAt,
-				UpdatedAt: user.UpdatedAt,
+		want := Response[[]domain.PublicUser]{
+			Count: 1,
+			Data: []domain.PublicUser{
+				{
+					ID:        user.ID,
+					TenantID:  user.TenantID,
+					FirstName: user.FirstName,
+					LastName:  user.LastName,
+					Role:      user.Role,
+					CreatedAt: user.CreatedAt,
+					UpdatedAt: user.UpdatedAt,
+				},
 			},
 		}
 		assert.Equal(t, want, got, "users should be equal")
@@ -227,20 +225,18 @@ func TestUpdateUser(t *testing.T) {
 			return updatedUser, nil
 		}
 
-		message := "user was updated successfully"
-		want := Response[domain.PublicUser]{
-			Success: true,
-			Message: &message,
-			Count:   1,
-			Type:    "users",
-			Data: domain.PublicUser{
-				ID:        user.ID,
-				TenantID:  user.TenantID,
-				FirstName: *update.FirstName, // updated field
-				LastName:  user.LastName,
-				Role:      *update.Role, // updated field
-				CreatedAt: user.CreatedAt,
-				UpdatedAt: user.UpdatedAt,
+		want := Response[[]domain.PublicUser]{
+			Count: 1,
+			Data: []domain.PublicUser{
+				{
+					ID:        user.ID,
+					TenantID:  user.TenantID,
+					FirstName: *update.FirstName, // updated field
+					LastName:  user.LastName,
+					Role:      *update.Role, // updated field
+					CreatedAt: user.CreatedAt,
+					UpdatedAt: user.UpdatedAt,
+				},
 			},
 		}
 
@@ -249,7 +245,7 @@ func TestUpdateUser(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "/api/tenants/1/users/3", bodyBuff)
 		res := newUserRequest(userStore, req)
 
-		var got Response[domain.PublicUser]
+		var got Response[[]domain.PublicUser]
 		json.NewDecoder(res.Body).Decode(&got)
 		assert.Equal(t, want, got, "they should be equal")
 	})
@@ -283,7 +279,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	t.Run("returns 200 on success", func(t *testing.T) {
+	t.Run("returns 204 on success", func(t *testing.T) {
 		req := httptest.NewRequest("DELETE", "/api/tenants/1/users/2", nil)
 		userstore := new(mock.UserStore)
 		userstore.DeleteByIDFn = func(ctx context.Context, tenantID int, userID int) error {
@@ -292,7 +288,7 @@ func TestDelete(t *testing.T) {
 
 		res := newUserRequest(userstore, req)
 		got := res.Code
-		want := 200
+		want := 204
 		assert.Equal(t, want, got, "status codes should be equal")
 	})
 
@@ -348,10 +344,8 @@ func TestGetAllUsers(t *testing.T) {
 		json.NewDecoder(res.Body).Decode(&got)
 
 		want := Response[[]domain.PublicUser]{
-			Success: true,
-			Count:   1,
-			Type:    "users",
-			Data:    MapToPublicUsers(users),
+			Count: 1,
+			Data:  MapToPublicUsers(users),
 		}
 
 		assert.Equal(t, want, got, "responses should match")


### PR DESCRIPTION
This pull request changes API response structure with the following:

1- Removes unnecessary fields in response struct such as Message and Success
2- Changes response status for DELETE endpoint from 200 to 204, since its response was empty on success to begin with.