### PR TITLE
fixes update user method on user store to use transaction rather than…

### DIFF
--- a/postgres/users.go
+++ b/postgres/users.go
@@ -68,12 +68,16 @@ func (s *Store) UpdateUser(ctx context.Context, tenantID int, userID int, update
 	}
 	defer tx.Rollback(ctx)
 
-	rows, err := s.pool.Query(ctx, query, columnValues...)
+	rows, err := tx.Query(ctx, query, columnValues...)
 	if err != nil {
 		return domain.User{}, err
 	}
 
 	updatedUser, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[domain.User])
+	if err != nil {
+		return domain.User{}, err
+	}
+	err = tx.Commit(ctx)
 	if err != nil {
 		return domain.User{}, err
 	}


### PR DESCRIPTION
The update user method on user store was querying the database with the ```dbpool``` rather than using the transaction which was started in the same method, thus rendering transaction useless. This was not the intended behavior as all data store methods query the database with transactions.

This pull request fixes that issue.