### PR TITLE
Refactor error handling logic

### DIFF
--- a/cmd/http/server.go
+++ b/cmd/http/server.go
@@ -48,6 +48,7 @@ func main() {
 	server := http.NewServer(dbpool, logger)
 
 	server.Use(middleware.Logger)
+	server.Use(middleware.SetHeader("Content-Type", "application/json"))
 	server.Use(middleware.AddRequestID)
 
 	err = server.ListenAndServe(8080)


### PR DESCRIPTION
This pull request moves the code that adds context to errors from the ```errorHandler's ServeHTTP``` to ```appError's withContext``` method. This makes easier to understand that withContext actually adds context to errors rather than just setting ```appError's``` fields, which is how the code was initially. In addition, it also makes  ```errorHandler's ServeHTTP``` much cleaner with only one single responsibilty, which is to handle errors by logging them and sending the error response to the user as initially intended.